### PR TITLE
0.1.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ pip install filequery
 Run `filequery --help` to see what options are available.
 
 ```
-usage: __main__.py [-h] [--filename FILENAME] [--filesdir FILESDIR] [--query QUERY] [--query_file QUERY_FILE] [--out_file OUT_FILE [OUT_FILE ...]] [--out_file_format OUT_FILE_FORMAT] [--config CONFIG]
+usage: __main__.py [-h] [--filename FILENAME] [--filesdir FILESDIR] [--query QUERY] [--query_file QUERY_FILE] [--out_file OUT_FILE [OUT_FILE ...]] [--out_file_format OUT_FILE_FORMAT] [--delimiter DELIMITER] [--config CONFIG]
 
 options:
   -h, --help            show this help message and exit
@@ -23,6 +23,8 @@ options:
                         file to write results to instead of printing to standard output
   --out_file_format OUT_FILE_FORMAT
                         either csv or parquet, defaults to csv
+  --delimiter DELIMITER
+                        delimiter to use when printing result or writing to CSV file
   --config CONFIG       path to JSON config file
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Query CSV and Parquet files using SQL. This uses DuckDB behind the scenes so any
 Run `filequery --help` to see what options are available.
 
 ```
-usage: __main__.py [-h] [--filename FILENAME] [--filesdir FILESDIR] [--query QUERY] [--query_file QUERY_FILE] [--out_file OUT_FILE] [--out_file_format OUT_FILE_FORMAT] [--config CONFIG]
+usage: __main__.py [-h] [--filename FILENAME] [--filesdir FILESDIR] [--query QUERY] [--query_file QUERY_FILE] [--out_file OUT_FILE [OUT_FILE ...]] [--out_file_format OUT_FILE_FORMAT] [--config CONFIG]
 
 options:
   -h, --help            show this help message and exit
@@ -17,7 +17,8 @@ options:
   --query QUERY         SQL query to execute against file
   --query_file QUERY_FILE
                         path to file with query to execute
-  --out_file OUT_FILE   file to write results to instead of printing to standard output
+  --out_file OUT_FILE [OUT_FILE ...]
+                        file to write results to instead of printing to standard output
   --out_file_format OUT_FILE_FORMAT
                         either csv or parquet, defaults to csv
   --config CONFIG       path to JSON config file
@@ -26,11 +27,27 @@ options:
 For basic usage, provide a path to a CSV or Parquet file and a query to execute against it. The table name will be the 
 file name without the extension.
 
-`$ filequery --filename example/test.csv --query 'select * from test'`\
-`$ filequery --filename example/json_test.json --query 'select nested.nest_id, nested.nested_val from json_test'`\
-`$ filequery --filesdir example/data --query 'select * from test inner join test1 on test.col1 = test1.col1'` \
-`$ filequery --filesdir example/data --query_file example/queries/join.sql`\
-`$ filequery --filesdir example/data --query_file example/queries/json_csv_join.sql`
+```bash
+filequery --filename example/test.csv --query 'select * from test'
+```
+
+Examples
+
+```bash
+filequery --filename example/json_test.json --query 'select nested.nest_id, nested.nested_val from json_test' # query json
+```
+```bash
+filequery --filesdir example/data --query 'select * from test inner join test1 on test.col1 = test1.col1' # query multiple files in a directory
+```
+```bash
+filequery --filesdir example/data --query_file example/queries/join.sql # point to a file containing SQL
+```
+```bash
+filequery --filesdir example/data --query_file example/queries/json_csv_join.sql # SQL file joining data from JSON and CSV files
+```
+```bash
+filequery --filesdir example/test.csv --query 'select * from test; select sum(col3) from test;' # output multiple query results to multiple files
+```
 
 You can also provide a config file instead of specifying the arguments when running the command.
 
@@ -38,14 +55,14 @@ You can also provide a config file instead of specifying the arguments when runn
 
 The config file should be a json file. See example config file contents below.
 
-```
+```json
 {
     "filename": "../example/test.csv",
     "query": "select col1, col2 from test"
 }
 ```
 
-```
+```json
 {
     "filesdir": "../example/data",
     "query_file": "../example/queries/join.sql",
@@ -54,9 +71,12 @@ The config file should be a json file. See example config file contents below.
 }
 ```
 
+See the `example` directory in the repo for more examples.
+
 ## module usage
 You can also use filequery in your own programs. See the example below.
-```
+
+```python
 from filequery.filedb import FileDb
 
 query = 'select * from test'

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 Query CSV and Parquet files using SQL. This uses DuckDB behind the scenes so any valid SQL for DuckDB will work here.
 
 ## installation
-`$ pip install filequery`
+```bash
+pip install filequery
+```
 
 ## CLI usage
 Run `filequery --help` to see what options are available.
@@ -51,7 +53,9 @@ filequery --filesdir example/test.csv --query 'select * from test; select sum(co
 
 You can also provide a config file instead of specifying the arguments when running the command.
 
-`$ filequery --config <path to config file>`
+```bash
+filequery --config <path to config file>
+```
 
 The config file should be a json file. See example config file contents below.
 
@@ -102,14 +106,20 @@ Packages required for distribution should go in `requirements.txt`.
 
 To build the wheel:
 
-`$ pip install -r requirements-dev.txt` \
-`$ make`
+```bash
+pip install -r requirements-dev.txt
+make
+```
 
 ## testing
 To test the CLI, cd into the `src` directory and run `filequery` as a module.
 
-`$ python -m filequery <args>`
+```bash
+python -m filequery ...
+```
 
 To run unit tests, stay in the root of the project. The unit tests add `src` to the path so `filequery` can be imported properly.
 
-`$ python tests/<test file>`
+```bash
+python tests/test_filequery.py
+```

--- a/example/config_files/example5.json
+++ b/example/config_files/example5.json
@@ -1,0 +1,9 @@
+{
+    "filesdir": "../example/data",
+    "query_file": "../example/queries/multi_query.sql",
+    "out_file": [
+        "result1.csv",
+        "result2.csv",
+        "result3.csv"
+    ]
+}

--- a/example/config_files/example6.json
+++ b/example/config_files/example6.json
@@ -1,0 +1,6 @@
+{
+    "filename": "../example/test.csv",
+    "query": "select col1, col2, col3 from test",
+    "out_file": "pipe_delim.csv",
+    "delimiter": "|"
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 license = {text = "MIT"}
-version = "0.1.6"
+version = "0.1.7"
 dynamic = ["dependencies"]
 
 [tool.setuptools.dynamic]

--- a/src/filequery/__init__.py
+++ b/src/filequery/__init__.py
@@ -56,6 +56,7 @@ def parse_config_file(config_file: str):
             config.get('query_file'),
             outfiles,
             config.get('out_file_format'),
+            config.get('delimiter')
         )
     
     return args

--- a/src/filequery/file_query_args.py
+++ b/src/filequery/file_query_args.py
@@ -9,3 +9,4 @@ class FileQueryArgs:
     query_file: str
     out_file: List[str]
     out_file_format: str
+    delimiter: str

--- a/src/filequery/file_query_args.py
+++ b/src/filequery/file_query_args.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import List
 
 @dataclass
 class FileQueryArgs:
@@ -6,5 +7,5 @@ class FileQueryArgs:
     filesdir: str
     query: str
     query_file: str
-    out_file: str
+    out_file: List[str]
     out_file_format: str

--- a/src/filequery/filedb.py
+++ b/src/filequery/filedb.py
@@ -61,7 +61,7 @@ class FileDb:
         results = [self.exec_query(query) for query in queries]
         return results
 
-    def export_query(self, query: str, output_filepath: str, filetype: int = FileType.CSV):
+    def export_query(self, query: str, output_filepath: str, filetype: int = FileType.CSV, **kwargs):
         """
         Writes query result to a file
 
@@ -73,6 +73,7 @@ class FileDb:
         :type filetype: FileType.CSV
         """
         if filetype == FileType.CSV:
-            self.db.execute(f"copy ({query}) to '{output_filepath}' (header, delimiter ',')")
+            delimiter = ',' if 'delimiter' not in kwargs else kwargs['delimiter']
+            self.db.execute(f"copy ({query}) to '{output_filepath}' (header, delimiter '{delimiter}')")
         elif filetype == FileType.PARQUET:
             self.db.execute(f"copy ({query}) to '{output_filepath}'")

--- a/src/filequery/filedb.py
+++ b/src/filequery/filedb.py
@@ -65,8 +65,6 @@ class FileDb:
         """
         Writes query result to a file
 
-        TODO: allow multiple queries to be expored to multiple files
-
         :param query: query to execute
         :type query: str
         :param output_filepath: path to output file

--- a/src/filequery/queryresult.py
+++ b/src/filequery/queryresult.py
@@ -24,20 +24,37 @@ class QueryResult:
         return formatted
 
     def __str__(self) -> str:
-        header_str = ','.join(map(self.__format_field, self.result_cols))
-        records_str = '\n'.join([','.join(map(self.__format_field, rec)) for rec in self.records])
+        # formats as a csv
+        return self.format_with_delimiter(',')
+    
+    def format_with_delimiter(self, delimiter):
+        header_str = delimiter.join(map(self.__format_field, self.result_cols))
+        records_str = '\n'.join([delimiter.join(map(self.__format_field, rec)) for rec in self.records])
 
         return f'{header_str}\n{records_str}'
 
-    def format_as_table(self) -> str:
+    def format_as_table(self, delimiter: str = None) -> str:
+        """
+        Formats query result as a string in a tabular format
+
+        :param delimiter: specify a delimiter to format like a delimited file, if not specified, the result will be a "pretty" format, defaults to None
+        :type delimiter: str, optional
+        :return: query result as a tabular-formatted string
+        :rtype: str
+        """
+        if delimiter:
+            return self.format_with_delimiter(delimiter)
+
         return tabulate(self.records, headers=self.result_cols, tablefmt='fancy_grid')
 
-    def save_to_file(self, filepath: str):
+    def save_to_file(self, filepath: str, delimiter: str = ','):
         """
         Saves query reslt as a CSV
 
         :param filepath: path to output file
         :type filepath: str
+        :param delimiter: delimiter to use in output file, defaults to ','
+        :type filepath: str
         """
         with open(filepath, 'w') as outfile:
-            outfile.write(str(self))
+            outfile.write(self.format_with_delimiter(delimiter))

--- a/tests/test_filequery.py
+++ b/tests/test_filequery.py
@@ -86,6 +86,17 @@ class TestFileQuery(unittest.TestCase):
         self.assertEqual(len(res.records), 3)
 
     # TODO add tests for joining JSON, CSV and parquet files
+    def test_join_json_and_csv(self):
+        fdb = FileDb('example/data/')
+        res = fdb.exec_query("""
+            select *
+            from 
+                test t1
+                inner join test1 t2
+                on t1.col1 = t2.col1;
+        """)
+
+        self.assertEqual(len(res.records), 2)
 
 class TestFileQueryCli(unittest.TestCase):
     def test_no_filename_or_filesdir(self):

--- a/tests/test_filequery.py
+++ b/tests/test_filequery.py
@@ -85,6 +85,8 @@ class TestFileQuery(unittest.TestCase):
 
         self.assertEqual(len(res.records), 3)
 
+    # TODO add tests for joining JSON, CSV and parquet files
+
 class TestFileQueryCli(unittest.TestCase):
     def test_no_filename_or_filesdir(self):
         args = FileQueryArgs(

--- a/tests/test_filequery.py
+++ b/tests/test_filequery.py
@@ -144,12 +144,15 @@ class TestFileQueryCli(unittest.TestCase):
 
         self.assertIsNotNone(err)
 
+    # TODO test handle_args and output files
+
 
 if __name__ == '__main__':
     unittest.main()
     
     # for one-off testing
     # fdb = FileDb('example/test.csv')
+    # fdb.export_database('test')
     # res = fdb.exec_query('select * from test')
     
     # print(res)

--- a/tests/test_filequery.py
+++ b/tests/test_filequery.py
@@ -111,7 +111,8 @@ class TestFileQueryCli(unittest.TestCase):
             query='select * from test',
             query_file=None,
             out_file=None,
-            out_file_format=None
+            out_file_format=None,
+            delimiter=None
         )
 
         err = validate_args(args)
@@ -125,7 +126,8 @@ class TestFileQueryCli(unittest.TestCase):
             query='select * from test',
             query_file=None,
             out_file=None,
-            out_file_format=None
+            out_file_format=None,
+            delimiter=None
         )
 
         err = validate_args(args)
@@ -139,7 +141,8 @@ class TestFileQueryCli(unittest.TestCase):
             query=None,
             query_file=None,
             out_file=None,
-            out_file_format=None
+            out_file_format=None,
+            delimiter=None
         )
 
         err = validate_args(args)
@@ -153,7 +156,8 @@ class TestFileQueryCli(unittest.TestCase):
             query='select * from test',
             query_file='example/queries/join.sql',
             out_file=None,
-            out_file_format=None
+            out_file_format=None,
+            delimiter=None
         )
 
         err = validate_args(args)
@@ -191,7 +195,8 @@ class TestFileQueryCli(unittest.TestCase):
             query='select * from test',
             query_file=None,
             out_file=[out_file],
-            out_file_format=None
+            out_file_format=None,
+            delimiter=None
         )
 
         self.handle_args_single_out_file(args, out_file)
@@ -205,7 +210,8 @@ class TestFileQueryCli(unittest.TestCase):
             query='select * from test',
             query_file=None,
             out_file=[out_file],
-            out_file_format='csv'
+            out_file_format='csv',
+            delimiter=None
         )
 
         self.handle_args_single_out_file(args, out_file)
@@ -219,7 +225,8 @@ class TestFileQueryCli(unittest.TestCase):
             query='select * from test',
             query_file=None,
             out_file=[out_file],
-            out_file_format='parquet'
+            out_file_format='parquet',
+            delimiter=None
         )
 
         self.handle_args_single_out_file(args, out_file)
@@ -233,7 +240,8 @@ class TestFileQueryCli(unittest.TestCase):
             query='select * from test; select sum(col3) from test; select col1 from test where col1 = 1;',
             query_file=None,
             out_file=out_files,
-            out_file_format=None
+            out_file_format=None,
+            delimiter=None
         )
 
         self.handle_args_multiple_out_files(args)
@@ -247,7 +255,8 @@ class TestFileQueryCli(unittest.TestCase):
             query='select * from test; select sum(col3) from test; select col1 from test where col1 = 1;',
             query_file=None,
             out_file=out_files,
-            out_file_format='csv'
+            out_file_format='csv',
+            delimiter=None
         )
 
         self.handle_args_multiple_out_files(args)
@@ -261,7 +270,8 @@ class TestFileQueryCli(unittest.TestCase):
             query='select * from test; select sum(col3) from test; select col1 from test where col1 = 1;',
             query_file=None,
             out_file=out_files,
-            out_file_format='parquet'
+            out_file_format='parquet',
+            delimiter=None
         )
 
         self.handle_args_multiple_out_files(args)

--- a/tests/test_filequery.py
+++ b/tests/test_filequery.py
@@ -10,9 +10,9 @@ sys.path.append(src_path)
 sample_data_path = os.path.join(os.getcwd(), 'example')
 sys.path.append(sample_data_path)
 
-from filequery import validate_args
+from filequery import validate_args, handle_args
 from filequery.file_query_args import FileQueryArgs
-from filequery.filedb import FileDb
+from filequery.filedb import FileDb, FileType
 from filequery.queryresult import QueryResult
 
 class TestFileQuery(unittest.TestCase):
@@ -99,6 +99,11 @@ class TestFileQuery(unittest.TestCase):
         self.assertEqual(len(res.records), 2)
 
 class TestFileQueryCli(unittest.TestCase):
+
+    #####################################################
+    # tests for invalid arguments
+    #####################################################
+
     def test_no_filename_or_filesdir(self):
         args = FileQueryArgs(
             filename=None,
@@ -155,7 +160,111 @@ class TestFileQueryCli(unittest.TestCase):
 
         self.assertIsNotNone(err)
 
-    # TODO test handle_args and output files
+    #####################################################
+    # tests for handling arguments 
+    #####################################################
+
+    def handle_args_single_out_file(self, args: FileQueryArgs, out_file: str):
+        # call handle_args for creating an output file, check that the file exists, then delete the file
+        handle_args(args)
+        self.assertTrue(os.path.exists(out_file))
+
+        # cleanup
+        os.remove(out_file)
+
+    def handle_args_multiple_out_files(self, args: FileQueryArgs):
+        # call handle_args for creating multiple output files, check that each file exists, then delete the files
+        handle_args(args)
+
+        for file in args.out_file:
+            self.assertTrue(os.path.exists(file))
+
+            # cleanup
+            os.remove(file)
+
+    def test_single_output_file_default(self):
+        out_file = 'test_result.csv'
+
+        args = FileQueryArgs(
+            filename='example/test.csv',
+            filesdir=None,
+            query='select * from test',
+            query_file=None,
+            out_file=[out_file],
+            out_file_format=None
+        )
+
+        self.handle_args_single_out_file(args, out_file)
+
+    def test_single_output_file_csv(self):
+        out_file = 'test_result.csv'
+
+        args = FileQueryArgs(
+            filename='example/test.csv',
+            filesdir=None,
+            query='select * from test',
+            query_file=None,
+            out_file=[out_file],
+            out_file_format='csv'
+        )
+
+        self.handle_args_single_out_file(args, out_file)
+
+    def test_single_output_file_parquet(self):
+        out_file = 'test_result.parquet'
+
+        args = FileQueryArgs(
+            filename='example/test.csv',
+            filesdir=None,
+            query='select * from test',
+            query_file=None,
+            out_file=[out_file],
+            out_file_format='parquet'
+        )
+
+        self.handle_args_single_out_file(args, out_file)
+
+    def test_multiple_output_files_default(self):
+        out_files = ['test_result1.csv', 'test_result2.csv', 'test_result3.csv']
+
+        args = FileQueryArgs(
+            filename='example/test.csv',
+            filesdir=None,
+            query='select * from test; select sum(col3) from test; select col1 from test where col1 = 1;',
+            query_file=None,
+            out_file=out_files,
+            out_file_format=None
+        )
+
+        self.handle_args_multiple_out_files(args)
+
+    def test_multiple_output_files_csv(self):
+        out_files = ['test_result1.csv', 'test_result2.csv', 'test_result3.csv']
+
+        args = FileQueryArgs(
+            filename='example/test.csv',
+            filesdir=None,
+            query='select * from test; select sum(col3) from test; select col1 from test where col1 = 1;',
+            query_file=None,
+            out_file=out_files,
+            out_file_format='csv'
+        )
+
+        self.handle_args_multiple_out_files(args)
+
+    def test_multiple_output_files_parquet(self):
+        out_files = ['test_result1.parquet', 'test_result2.parquet', 'test_result3.parquet']
+
+        args = FileQueryArgs(
+            filename='example/test.csv',
+            filesdir=None,
+            query='select * from test; select sum(col3) from test; select col1 from test where col1 = 1;',
+            query_file=None,
+            out_file=out_files,
+            out_file_format='parquet'
+        )
+
+        self.handle_args_multiple_out_files(args)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- allow for multiple output files
    - Can now specify multiple queries and multiple output files to save a file for each query result. If the number of queries does not match the number of output files, it will cause an error
- can specify a delimiter when printing query results to standard out or when saving results to one or more CSVs