### PR TITLE
JSON export and dictionary formatting

### DIFF
--- a/src/filequery/filedb.py
+++ b/src/filequery/filedb.py
@@ -110,5 +110,7 @@ class FileDb:
             self.db.execute(
                 f"copy ({query}) to '{output_filepath}' (header, delimiter '{delimiter}')"
             )
+        elif filetype == FileType.JSON:
+            self.db.execute(f"copy ({query}) to '{output_filepath}' (ARRAY true)")
         elif filetype == FileType.PARQUET:
             self.db.execute(f"copy ({query}) to '{output_filepath}'")

--- a/src/filequery/queryresult.py
+++ b/src/filequery/queryresult.py
@@ -6,9 +6,6 @@ from rich.table import Table
 
 
 class QueryResult:
-    result_cols: List[str]
-    records: List[List[Any]]
-
     def __init__(self, result: Dict[str, np.ndarray]):
         self.result_cols = {}
 
@@ -34,6 +31,20 @@ class QueryResult:
     def __str__(self) -> str:
         # formats as a csv
         return self.format_with_delimiter(",")
+    
+    @property
+    def dict_records(self) -> List[Dict[str, Any]]:
+        result = []
+
+        for rec in self.records:
+            dict_record = {}
+
+            for key, value in zip(self.result_cols, rec):
+                dict_record[key] = value
+
+            result.append(dict_record)
+
+        return result
 
     def format_with_delimiter(self, delimiter):
         col_names = list(self.result_cols.keys())

--- a/tests/test_filequery.py
+++ b/tests/test_filequery.py
@@ -111,6 +111,39 @@ class TestFileQuery(unittest.TestCase):
 
         self.assertEqual(len(res.records), 4)
 
+    def test_dict_records_length_csv(self):
+        fdb = FileDb("example/test.csv")
+        res = fdb.exec_query("select * from test")
+
+        self.assertEqual(len(res.dict_records), 3)
+
+    def test_dict_records_keys_csv(self):
+        fdb = FileDb("example/test.csv")
+        res = fdb.exec_query("select * from test")
+
+        for rec in res.dict_records:
+            self.assertListEqual(list(rec.keys()), ["col1", "col2", "col3"])
+
+    def test_dict_records_length_json(self):
+        fdb = FileDb("example/ndjson_test.ndjson")
+        res = fdb.exec_query("select * from ndjson_test")
+
+        self.assertEqual(len(res.dict_records), 4)
+
+    def test_dict_records_keys_json(self):
+        fdb = FileDb("example/ndjson_test.ndjson")
+        res = fdb.exec_query("select * from ndjson_test")
+        
+        for rec in res.dict_records:
+            self.assertListEqual(list(rec.keys()), ["id", "value", "nested"])
+
+    def test_dict_records_nested_keys_json(self):
+        fdb = FileDb("example/ndjson_test.ndjson")
+        res = fdb.exec_query("select * from ndjson_test")
+        
+        for rec in res.dict_records:
+            self.assertListEqual(list(rec["nested"].keys()), ["subid", "subval"])
+
 
 class TestFileQueryCli(unittest.TestCase):
     #####################################################


### PR DESCRIPTION
- `FileDb` support for exporting query result to a JSON file as a list of JSON documents
- added `dict_records` property to `QueryResult` to allow users to retrieve the records as a list of dictionaries