### PR TITLE
CSV parsing

### DIFF
--- a/src/filequery/filedb.py
+++ b/src/filequery/filedb.py
@@ -8,7 +8,7 @@ from .filetype import FileType
 from .queryresult import QueryResult
 
 READ_FUNCS = {
-    FileType.CSV: "read_csv_auto",
+    FileType.CSV: "read_csv",
     FileType.PARQUET: "read_parquet",
     FileType.JSON: "read_json_auto",
     FileType.NDJSON: "read_ndjson_auto",


### PR DESCRIPTION
use read_csv instead of read_csv_auto since they do the same thing since duckdb 0.10.0