### PR TITLE
File name and Rich table bug fixes

### DIFF
--- a/example/data/test-filename.csv
+++ b/example/data/test-filename.csv
@@ -1,0 +1,4 @@
+col1,col2,col3
+1,test 1,0.1
+2,test 2,0.2
+3,test 3,0.3

--- a/example/data/test_special_chars.csv
+++ b/example/data/test_special_chars.csv
@@ -1,0 +1,7 @@
+col1,col2
+1,[asdf
+2,[]asdf[/]
+3,[bold]asdf[/bold]
+4,]asdf
+5,[bold]asdf
+6,[]asdf

--- a/src/filequery/queryresult.py
+++ b/src/filequery/queryresult.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, List
 
 import numpy as np
+from rich import markup
 from rich.console import Console
 from rich.table import Table
 
@@ -74,7 +75,7 @@ class QueryResult:
                 table.add_column(col, justify=justify)
 
             for rec in self.records:
-                stringified = [str(r) for r in rec]
+                stringified = [markup.escape(str(r)) for r in rec]
                 table.add_row(*stringified)
 
             console = Console()

--- a/tests/test_filequery.py
+++ b/tests/test_filequery.py
@@ -133,16 +133,28 @@ class TestFileQuery(unittest.TestCase):
     def test_dict_records_keys_json(self):
         fdb = FileDb("example/ndjson_test.ndjson")
         res = fdb.exec_query("select * from ndjson_test")
-        
+
         for rec in res.dict_records:
             self.assertListEqual(list(rec.keys()), ["id", "value", "nested"])
 
     def test_dict_records_nested_keys_json(self):
         fdb = FileDb("example/ndjson_test.ndjson")
         res = fdb.exec_query("select * from ndjson_test")
-        
+
         for rec in res.dict_records:
             self.assertListEqual(list(rec["nested"].keys()), ["subid", "subval"])
+
+    def test_valid_unquoted_identifier(self):
+        fdb = FileDb("example/test.csv")
+        should_quote = fdb._should_quote_table_name("test_table")
+
+        self.assertFalse(should_quote)
+
+    def test_filename_with_hyphen(self):
+        fdb = FileDb("example/test.csv")
+        should_quote = fdb._should_quote_table_name("test-table")
+
+        self.assertTrue(should_quote)
 
 
 class TestFileQueryCli(unittest.TestCase):

--- a/tests/test_filequery.py
+++ b/tests/test_filequery.py
@@ -150,9 +150,45 @@ class TestFileQuery(unittest.TestCase):
 
         self.assertFalse(should_quote)
 
+    def test_filename_with_leading_underscore(self):
+        fdb = FileDb("example/test.csv")
+        should_quote = fdb._should_quote_table_name("_test_table")
+
+        self.assertFalse(should_quote)
+
+    def test_filename_with_numbers(self):
+        fdb = FileDb("example/test.csv")
+        should_quote = fdb._should_quote_table_name("test_table_1")
+
+        self.assertFalse(should_quote)
+
     def test_filename_with_hyphen(self):
         fdb = FileDb("example/test.csv")
         should_quote = fdb._should_quote_table_name("test-table")
+
+        self.assertTrue(should_quote)
+
+    def test_filename_with_leading_number(self):
+        fdb = FileDb("example/test.csv")
+        should_quote = fdb._should_quote_table_name("1test")
+
+        self.assertTrue(should_quote)
+
+    def test_filename_with_spaces(self):
+        fdb = FileDb("example/test.csv")
+        should_quote = fdb._should_quote_table_name("test table")
+
+        self.assertTrue(should_quote)
+
+    def test_filename_with_leading_special_char(self):
+        fdb = FileDb("example/test.csv")
+        should_quote = fdb._should_quote_table_name("$test")
+
+        self.assertTrue(should_quote)
+
+    def test_filename_with_leading_space(self):
+        fdb = FileDb("example/test.csv")
+        should_quote = fdb._should_quote_table_name(" test")
 
         self.assertTrue(should_quote)
 


### PR DESCRIPTION
- escape data in Rich tables so it treats the data as literal instead of trying to render it if it contains square brackets
- if a file name does not conform to DuckDB's [rules on unquoted identifiers](https://duckdb.org/docs/sql/keywords_and_identifiers.html), wrap it in double quotes